### PR TITLE
Release: v0.0.2

### DIFF
--- a/changelogs/v0.0.2.md
+++ b/changelogs/v0.0.2.md
@@ -1,0 +1,16 @@
+# CHANGELOG
+
+## v0.0.2
+
+This release adds more user and identity features to the space-sdk.
+
+### New Features
+
+- `Users.backupKeysByPassphrase` - Backup existing identity using a passphrase.
+- `Users.recoverKeysByPassphrase` - Recover existing identity using a passphrase.
+
+### New Fixes
+
+- `UserStorage` logic has been updated to now fetch buckets in threads similar to existing
+accounts created in the space-daemon. Existing accounts (identities) from space-daemon can
+  retrieve their data via the sdk.

--- a/etc/sdk.api.md
+++ b/etc/sdk.api.md
@@ -59,7 +59,7 @@ export interface AddItemsStatus {
     status: 'success' | 'error';
 }
 
-// @public (undocumented)
+// @public
 export class BrowserStorage {
     constructor();
     // (undocumented)
@@ -97,7 +97,7 @@ export class DirEntryNotFoundError extends Error {
     constructor(filePath: string, bucket: string);
 }
 
-// @public (undocumented)
+// @public
 export class FileStorage {
     constructor(filename: string);
     // (undocumented)
@@ -108,7 +108,17 @@ export class FileStorage {
     remove(key: string): Promise<void>;
     }
 
-// @public (undocumented)
+// Warning: (ae-internal-missing-underscore) The name "HubAuthResponse" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export interface HubAuthResponse {
+    // (undocumented)
+    storageAuth?: TextileStorageAuth;
+    // (undocumented)
+    token: string;
+}
+
+// @public
 export interface IdentityStorage {
     // (undocumented)
     add: (identity: Identity) => Promise<void>;
@@ -146,15 +156,12 @@ export interface OpenFileResponse {
     stream: AsyncIterableIterator<Uint8Array>;
 }
 
-// @public (undocumented)
+// @public
 export interface SpaceUser {
     // (undocumented)
     identity: Identity;
-    // Warning: (ae-forgotten-export) The symbol "TextileStorageAuth" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     storageAuth?: TextileStorageAuth;
-    // (undocumented)
     token: string;
 }
 
@@ -167,6 +174,18 @@ export class SpaceVaultService implements Vault {
 }
 
 // @public (undocumented)
+export interface TextileStorageAuth {
+    // (undocumented)
+    key: string;
+    // (undocumented)
+    msg: string;
+    // (undocumented)
+    sig: string;
+    // (undocumented)
+    token: string;
+}
+
+// @public (undocumented)
 export class UnauthenticatedError extends Error {
     constructor();
 }
@@ -175,21 +194,20 @@ export class UnauthenticatedError extends Error {
 export class Users {
     constructor(config: UsersConfig, storage?: IdentityStorage);
     authenticate(identity: Identity): Promise<SpaceUser>;
-    // (undocumented)
     backupKeysByPassphrase(uuid: string, passphrase: string, backupType: VaultBackupType, identity: Identity): Promise<void>;
-    // (undocumented)
     createIdentity(): Promise<Identity>;
-    // (undocumented)
     list(): SpaceUser[];
     recoverKeysByPassphrase(uuid: string, passphrase: string, backupType: VaultBackupType): Promise<SpaceUser>;
-    // (undocumented)
     remove(publicKey: string): Promise<void>;
-    // (undocumented)
     static withStorage(storage: IdentityStorage, config: UsersConfig, onError?: CallableFunction): Promise<Users>;
 }
 
 // @public
 export interface UsersConfig {
+    // Warning: (ae-incompatible-release-tags) The symbol "authChallengeSolver" is marked as @public, but its signature references "HubAuthResponse" which is marked as @internal
+    //
+    // (undocumented)
+    authChallengeSolver?: (identity: Identity) => Promise<HubAuthResponse>;
     endpoint: string;
     vaultInit?: () => Vault;
     vaultServiceConfig?: VaultServiceConfig;
@@ -223,8 +241,6 @@ export enum VaultBackupType {
     Email = "email",
     // (undocumented)
     Google = "google",
-    // (undocumented)
-    Password = "password",
     // (undocumented)
     Twitter = "twitter"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.1",
+  "version": "0.0.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -93,3 +93,133 @@ This includes operations to share your storage items with existing user (identit
 ```typescript
 // WIP
 ```
+
+## Migrating from Space Daemon
+If you are already familiar with the space daemon and its gRPC methods and would like to start using the space-sdk
+here are some pointers on how those gRPC methods correspond to functionalities exposed by the space-sdk.
+
+### Key Pairs (GenerateKeyPair)
+In the sdk the concept of Key Pairs is represented as an `Identity`.
+To create a new Identity similar to the `GenerateKeyPair` method, you would do:
+
+```typescript
+import { Users, BrowserStorage } from '@spacehq/sdk';
+
+const users = new Users({ endpoint: 'wss://auth-dev.space.storage' });
+
+// createIdentity generate a random keypair identity
+const identity = await users.createIdentity();
+```
+`identity` represents a keypair and its primary key is accessible via `identity.public.toString()`.
+
+### Managing authenticated users
+
+In space-daemon the generated keypair is stored in the operating systems keychain but in space-sdk you would
+need to provide an [IdentityStorage](https://fleekhq.github.io/space-sdk/docs/sdk.identitystorage) to the `Users` class when initializing it.
+For the browser environment there exists a [`BrowserStorage`](https://fleekhq.github.io/space-sdk/docs/sdk.browserstorage) implementation
+you can use.
+
+```typescript
+import { Users, BrowserStorage } from '@spacehq/sdk';
+
+const users = await Users.withStorage(
+    new BrowserStorage(), 
+    { endpoint: 'wss://auth-dev.space.storage' }
+);
+```
+
+`Users.withStorage` will load and authenticate all identities that exist inside the provided `IdentityStorage`.
+You can access all authenticated users through the [`Users.list`](https://fleekhq.github.io/space-sdk/docs/sdk.users.list) method.
+
+```typescript
+const spaceUsers = await users.list();
+```
+
+To authenticate a new user identity and get a [SpaceUser](https://fleekhq.github.io/space-sdk/docs/sdk.spaceuser), 
+you can call the [`Users.authenticate`](https://fleekhq.github.io/space-sdk/docs/sdk.users.authenticate) method:
+
+```typescript
+const spaceUser = await users.authenticate(identity);
+```
+
+`Users.authentication` would do two things:
+- Generate a [`SpaceUser`](https://fleekhq.github.io/space-sdk/docs/sdk.spaceuser). 
+- Stores the new users information in the `IdentityStorage`, so subsequent initialization of `Users.withStorage()` would 
+  have the users loaded.
+  
+NOTE: An existing space user can also be gotten from [`Users.recoverKeysByPassphrase`](https://fleekhq.github.io/space-sdk/docs/sdk.users.recoverkeysbypassphrase).  
+
+To delete a user from users lists, you can delete the user by pass the `publicKey` of that user to [`Users.remove`](https://fleekhq.github.io/space-sdk/docs/sdk.users.remove).
+
+```typescript
+await users.remove(spaceUser.identity.public.toString());
+```
+
+#### Managing current active user
+If you have the concept of a current active user in your application that uses space-sdk. We recommend that you keep track
+of that users public key in your application and use it to filter the [list](https://fleekhq.github.io/space-sdk/docs/sdk.users.list) 
+method's result to get the authenticated `SpaceUser` for that public key. 
+
+On logout, you can call the [remove](https://fleekhq.github.io/space-sdk/docs/sdk.users.remove) method to stop tracking the user.
+
+### GetAPISessionToken
+In space daemon GetAPISessionToken returns the message:
+
+```
+message GetAPISessionTokensResponse {
+  string hubToken = 1;
+  string servicesToken = 2;
+}
+```
+
+In order to get the `servicesToken` and `hubToken` for a particular user, you would need to authenticate that user identity:
+```typescript
+const spaceUser = await users.authenticate(identity);
+```
+The `spaceUser.token` value is the `servicesToken`, while the `spaceUser.storageAuth.token` is the `hubToken`.
+
+Also, note that when an existing user is recovered via the [`Users.recoverKeysByPassphrase`](https://fleekhq.github.io/space-sdk/docs/sdk.users.recoverkeysbypassphrase) 
+method, the `SpaceUser` returns is also authenticated and has the session tokens.
+
+### GetPublicKey
+In space daemon `GetPublicKey` returned the id of the current keypair in keychain, but since space-sdk returns the `identity`
+object. You can get the public key for a particular identity through `identity.public.toString()`.
+
+Also, an authenticated [`SpaceUser`](https://fleekhq.github.io/space-sdk/docs/sdk.spaceuser) identity can be found in the `identity` field.
+
+### Storage Methods (createFolder, listDirectory, openFile, addItems)
+The storage gRPC methods on space daemon can now be performed using the [`UserStorage`](https://fleekhq.github.io/space-sdk/docs/sdk.userstorage) class of the space-sdk.
+
+```typescript
+import { UserStorage, AddItemsResultSummary } from '@spacehq/sdk';
+
+const storage = new UserStorage(user);
+await storage.createFolder({ bucket: 'personal', path: 'topFolder' });
+const result = await storage.listDirectory({ path: '' });
+// result contains `topFolder` items
+
+// upload a file
+const uploadResponse = await spaceStorage.addItems({
+   bucket: 'personal',
+   files: [
+     {
+       path: 'file.txt',
+       content: 'plain-text-value',
+     },
+     {
+       path: 'space.png',
+       content: '', // could also be a ReadableStream<Uint8Array> or ArrayBuffer
+     }
+   ],
+});
+// uploadresponse is an event listener
+uploadResponse.once('done', (data: AddItemsEventData) => {
+  const summary = data as AddItemsResultSummary;
+  // returns a summary of all files and their upload status
+});
+
+// read content of an uploaded file
+const fileResponse = await storage.openFile({ bucket: 'personal', path: '/file.txt'});
+const fileContent = await fileResponse.consumeStream();
+// new TextDecoder('utf8').decode(actualTxtContent) == 'plain-text-value'
+```

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/sdk",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Space SDK Library",
   "main": "dist/index",
   "types": "dist/index",
@@ -33,7 +33,7 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
-    "@spacehq/storage": "^0.0.1",
-    "@spacehq/users": "^0.0.1"
+    "@spacehq/storage": "^0.0.2",
+    "@spacehq/users": "^0.0.2"
   }
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/storage",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Space storage implementation",
   "main": "dist/index",
   "types": "dist/index",
@@ -38,7 +38,7 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
-    "@spacehq/users": "^0.0.1",
+    "@spacehq/users": "^0.0.2",
     "@textile/crypto": "^2.0.0",
     "@textile/hub": "^4.1.0",
     "@textile/threads-id": "^0.4.0",

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/users",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Space users implementation",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/users/src/identity/browserStorage.ts
+++ b/packages/users/src/identity/browserStorage.ts
@@ -1,6 +1,10 @@
 import { Identity, PrivateKey } from '@textile/crypto';
 import localForage from 'localforage';
 
+/**
+ * BrowserStorage is an {@link @spacehq/sdk#IdentityStorage} implementation that works in the browser.
+ *
+ */
 export class BrowserStorage {
   private db: LocalForage;
 

--- a/packages/users/src/identity/fileStorage.ts
+++ b/packages/users/src/identity/fileStorage.ts
@@ -2,7 +2,13 @@ import { Identity, PrivateKey } from '@textile/crypto';
 import fs from 'fs';
 import _ from 'lodash';
 
-// experimental, do not use yet
+/**
+ * FileStorage is an {@link @spacehq/sdk#IdentityStorage} implementation that works in the browser.
+ *
+ * NOTE: This is experimental, you might want to roll your own IdentityStorage of early.
+ *
+ * @experimental
+ */
 export class FileStorage {
   private filename: string;
 

--- a/packages/users/src/users.ts
+++ b/packages/users/src/users.ts
@@ -35,6 +35,12 @@ export interface SpaceUser {
   storageAuth?: TextileStorageAuth;
 }
 
+/**
+ * An IdentityStorage handles persistence of Identity for the {@link Users} class.
+ *
+ * The sdk provides two implementation for this.
+ * See {@link @spacehq/sdk#BrowserStorage} and {@link @spacehq/sdk#FileStorage}.
+ */
 export interface IdentityStorage {
   list: () => Promise<Identity[]>;
   add: (identity: Identity) => Promise<void>;
@@ -121,6 +127,9 @@ export class Users {
     this.users = {};
   }
 
+  /**
+   * Creates a users
+   */
   static async withStorage(storage: IdentityStorage, config: UsersConfig, onError?: CallableFunction) {
     const identities = await storage.list();
     const users = new Users(config, storage);
@@ -151,6 +160,13 @@ export class Users {
     return _.values(this.users);
   }
 
+  /**
+   * Removes the users identity from list of authenticated users.
+   *
+   * It also removes the identity from the {@link IdentityStorage} provided.
+   *
+   * @param publicKey - public key of users identity
+   */
   async remove(publicKey: string): Promise<void> {
     if (this.storage) {
       await this.storage.remove(publicKey);

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -9,7 +9,9 @@
     ],
     "Storage API": [
       "sdk.userstorage",
-      "sdk.identitystorage"
+      "sdk.identitystorage",
+      "sdk.browserstorage",
+      "sdk.filestorage"
     ]
   },
   "users-docs": {


### PR DESCRIPTION
# CHANGELOG

## v0.0.2

This release adds more user and identity features to the space-sdk.

### New Features

- `Users.backupKeysByPassphrase` - Backup existing identity using a passphrase.
- `Users.recoverKeysByPassphrase` - Recover existing identity using a passphrase.

### New Fixes

- `UserStorage` logic has been updated to now fetch buckets in threads similar to existing
accounts created in the space-daemon. Existing accounts (identities) from space-daemon can
  retrieve their data via the sdk.
