### PR TITLE
Fix: list directory parsing errors/integration issues

### DIFF
--- a/integration_tests/storage_interactions.spec.ts
+++ b/integration_tests/storage_interactions.spec.ts
@@ -83,6 +83,9 @@ describe('Users storing data', () => {
       },
     ]);
 
+    const listFolderRec = await storage.listDirectory({ bucket: 'personal', path: '',recursive: true });
+    console.log("listFolderRec: ", listFolderRec)
+
     // validate content of top.txt file
     const fileResponse = await storage.openFile({ bucket: 'personal', path: '/top.txt' });
     const actualTxtContent = await fileResponse.consumeStream();

--- a/integration_tests/storage_interactions.spec.ts
+++ b/integration_tests/storage_interactions.spec.ts
@@ -70,6 +70,17 @@ describe('Users storing data', () => {
       ],
     });
 
+    //3rd level upload
+    const anotheruploadResponse = await storage.addItems({
+      bucket: 'personal',
+      files: [
+        {
+          path: 'firstfolder/secondfolder/file.txt',
+          data: txtContent,
+        },
+      ],
+    });
+
     // validate files are in the directory
     const listFolder = await storage.listDirectory({ bucket: 'personal', path: '' });
     expect(listFolder.items).to.containSubset([
@@ -84,7 +95,6 @@ describe('Users storing data', () => {
     ]);
 
     const listFolderRec = await storage.listDirectory({ bucket: 'personal', path: '',recursive: true });
-    console.log("listFolderRec: ", listFolderRec)
 
     // validate content of top.txt file
     const fileResponse = await storage.openFile({ bucket: 'personal', path: '/top.txt' });

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -26,14 +26,30 @@ export interface ListDirectoryRequest {
 }
 
 /**
- * Represent an item stored in a storages directory
+ * Represents a member on a shared file
+ */
+export interface FileMember {
+  publicKey:string;
+  address?:string;
+}
+
+/**
+ * Represents an item stored in a storages directory
  */
 export interface DirectoryEntry {
   name: string;
   path: string;
-  cid: string;
+  ipfsHash: string;
   isDir: boolean;
-  size: number;
+  sizeInBytes: number;
+  created: Date;
+  updated: Date;
+  fileExtension: string;
+  isLocallyAvailable: boolean;
+  backupCount: number;
+  members: FileMember[];
+  isBackupInProgress: boolean;
+  isRestoreInProgress: boolean;
   items?: DirectoryEntry[];
 }
 

--- a/packages/storage/src/utils/fsUtils.spec.ts
+++ b/packages/storage/src/utils/fsUtils.spec.ts
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { isMetaFileName } from './fsUtils';
+
+describe('fsUtils', () => {
+  describe('isMetaFileName', () => {
+    const tests = [
+      { input: '/folder/randomfile.jpg', output: false },
+      { input: '/folder/randomfilewithnoextension', output: false },
+      { input: '/folder/trailingslash/', output: false },
+      { input: '/folder/.localized', output: true },
+      { input: '/folder/.textileseed', output: true },
+      { input: '/folder/.textile', output: true },
+      { input: '/folder/.DS_Store', output: true },
+      { input: '/folder/.Trashes', output: true },
+      { input: '/folder/.localized', output: true },
+    ];
+
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    tests.forEach(({ input, output }) => {
+      it(`isMetaFileName('${input}') returns '${output}'`, () => {
+        expect(isMetaFileName(input)).to.equal(output);
+      });
+    });
+  });
+});

--- a/packages/storage/src/utils/fsUtils.ts
+++ b/packages/storage/src/utils/fsUtils.ts
@@ -1,0 +1,20 @@
+import path from 'path';
+
+const metaFileNames = new Map();
+metaFileNames.set('.textileseed', true);
+metaFileNames.set('.textile', true);
+metaFileNames.set('.DS_Store', true);
+metaFileNames.set('.Trashes', true);
+metaFileNames.set('.localized', true);
+
+/**
+ * Checks if this is a built in file that could
+ * be ignored when returning results to a client
+ *
+ * @param pathOrName The name of the path or file
+ */
+export const isMetaFileName = (pathOrName: string): boolean => {
+  const name = path.basename(pathOrName);
+
+  return metaFileNames.get(name) || false;
+};


### PR DESCRIPTION
## Description
List directory response was not returning fields properly.  This adds the required parsing and formatting of response so that it aligns with the what the FE expects.

Fixes # (issue)
https://app.clubhouse.io/terminalsystems/story/21125/listdirectory-missing-fields

## Type of change
Which of the commands should be ran for updating the API docs?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Unit Test
- [x] Integration Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
