### PR TITLE
Fix: Use different threads for users Id

### DIFF
--- a/etc/sdk.api.md
+++ b/etc/sdk.api.md
@@ -150,13 +150,13 @@ export class FileStorage {
 export const GetAddressFromPublicKey: (pubkey: string) => string;
 
 // @public
-export class GunsdbMetadataStore implements UserMetadataStore {
+export class GundbMetadataStore implements UserMetadataStore {
     createBucket(bucketSlug: string, dbId: string): Promise<BucketMetadata>;
-    findBucket(bucketSlug: string, dbId: string): Promise<BucketMetadata | undefined>;
+    findBucket(bucketSlug: string): Promise<BucketMetadata | undefined>;
     findFileMetadata(bucketSlug: string, dbId: string, path: string): Promise<FileMetadata | undefined>;
     // Warning: (ae-forgotten-export) The symbol "GunChainReference" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "GunDataState" needs to be exported by the entry point index.d.ts
-    static fromIdentity(identity: Identity, gunOrServer?: GunChainReference<GunDataState> | string): Promise<GunsdbMetadataStore>;
+    static fromIdentity(username: string, userpass: string, gunOrServer?: GunChainReference<GunDataState> | string): Promise<GundbMetadataStore>;
     listBuckets(): Promise<BucketMetadata[]>;
     upsertFileMetadata(bucketSlug: string, dbId: string, path: string, metadata: FileMetadata): Promise<FileMetadata>;
     }
@@ -262,7 +262,7 @@ export class UnauthenticatedError extends Error {
 // @public
 export interface UserMetadataStore {
     createBucket: (bucketSlug: string, dbId: string) => Promise<BucketMetadata>;
-    findBucket: (bucketSlug: string, dbId: string) => Promise<BucketMetadata | undefined>;
+    findBucket: (bucketSlug: string) => Promise<BucketMetadata | undefined>;
     findFileMetadata: (bucketSlug: string, dbId: string, path: string) => Promise<FileMetadata | undefined>;
     listBuckets: () => Promise<BucketMetadata[]>;
     upsertFileMetadata: (bucketSlug: string, dbId: string, path: string, data: FileMetadata) => Promise<FileMetadata>;

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -2,4 +2,4 @@ export * from './errors';
 export * from './types';
 export * from './userStorage';
 export * from './metadata/metadataStore';
-export { GunsdbMetadataStore } from './metadata/gunsdbMetadataStore';
+export { GundbMetadataStore } from './metadata/gundbMetadataStore';

--- a/packages/storage/src/metadata/gundbMetadataStore.spec.ts
+++ b/packages/storage/src/metadata/gundbMetadataStore.spec.ts
@@ -3,17 +3,19 @@ import { PrivateKey } from '@textile/crypto';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as chaiSubset from 'chai-subset';
 import { expect, use } from 'chai';
-import { GunsdbMetadataStore } from './gunsdbMetadataStore';
+import { GundbMetadataStore } from './gundbMetadataStore';
 
 use(chaiAsPromised.default);
 use(chaiSubset.default);
 
 const identity: Identity = PrivateKey.fromRandom();
+const username = Buffer.from(identity.public.pubKey).toString('hex');
+const password = Buffer.from(identity.privKey).toString('hex');
 describe('GunsdbMetadataStore', () => {
   it('should work', async () => {
     const bucket = 'personal';
     const dbId = 'something';
-    const store = await GunsdbMetadataStore.fromIdentity(identity);
+    const store = await GundbMetadataStore.fromIdentity(username, password);
 
     // test create bucket data
     const newSchema = await store.createBucket(bucket, dbId);
@@ -23,13 +25,13 @@ describe('GunsdbMetadataStore', () => {
     expect(newSchema.encryptionKey).to.not.be.empty;
 
     // test find bucket data
-    const foundSchema = await store.findBucket(bucket, dbId);
+    const foundSchema = await store.findBucket(bucket);
     expect(foundSchema).to.containSubset({ dbId, slug: bucket });
     expect(Buffer.from(foundSchema?.encryptionKey || '').toString('hex')).to
       .equal(Buffer.from(newSchema.encryptionKey).toString('hex'));
 
     // ensure list bucket returns all value on fresh initialization
-    const newStore = await GunsdbMetadataStore.fromIdentity(identity);
+    const newStore = await GundbMetadataStore.fromIdentity(username, password);
 
     const existingBuckets = await newStore.listBuckets();
     expect(existingBuckets).to.containSubset([{ dbId, slug: bucket }]);
@@ -39,7 +41,7 @@ describe('GunsdbMetadataStore', () => {
     const bucket = 'personal';
     const dbId = 'something';
     const path = '/home/case.png';
-    const store = await GunsdbMetadataStore.fromIdentity(identity);
+    const store = await GundbMetadataStore.fromIdentity(username, password);
 
     await store.upsertFileMetadata(bucket, dbId, path, { mimeType: 'image/png' });
 

--- a/packages/storage/src/metadata/metadataStore.ts
+++ b/packages/storage/src/metadata/metadataStore.ts
@@ -17,7 +17,7 @@ export interface UserMetadataStore {
    * Find bucket metadata with slug belonging to the current user matching
    *
    */
-  findBucket: (bucketSlug: string, dbId: string) => Promise<BucketMetadata | undefined>;
+  findBucket: (bucketSlug: string) => Promise<BucketMetadata | undefined>;
 
   /**
    * Returns a list of all bucket schemas belonging to the current user

--- a/packages/storage/src/userStorage.spec.ts
+++ b/packages/storage/src/userStorage.spec.ts
@@ -60,7 +60,7 @@ const initStubbedStorage = (): { storage: UserStorage; mockBuckets: Buckets } =>
               dbId: 'dbId',
             });
           },
-          findBucket(bucketSlug: string, dbId: string): Promise<BucketMetadata | undefined> {
+          findBucket(bucketSlug: string): Promise<BucketMetadata | undefined> {
             return Promise.resolve({
               slug: 'myBucketKey',
               encryptionKey: new Uint8Array(80),

--- a/packages/storage/src/utils/threadsUtils.ts
+++ b/packages/storage/src/utils/threadsUtils.ts
@@ -1,3 +1,4 @@
+import { Identity } from '@spacehq/users';
 import { PrivateKey } from '@textile/crypto';
 import { ThreadID } from '@textile/threads-id';
 import { encode } from 'varint';
@@ -19,7 +20,7 @@ export enum ThreadKeyVariant {
  * @param variant The deterministic thread variant
  */
 export const getDeterministicThreadID = (
-  identity: PrivateKey,
+  identity: Identity,
   variant: DeterministicThreadVariant = DeterministicThreadVariant.MetathreadThreadVariant,
 ): ThreadID => {
   // We need the raw key, thus we use marshal() instead of bytes


### PR DESCRIPTION
## Description
This Fixes the GunDB Metadatastore logic and how user storage interacts with it. Now every new users bucket is created in a separate threadId, while the deterministic threadId is used as the password to authenticate the user in gundb.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Unit Test
- [x] Integration Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
