### PR TITLE
Release: v0.0.5

### DIFF
--- a/changelogs/v0.0.5.md
+++ b/changelogs/v0.0.5.md
@@ -1,0 +1,15 @@
+# CHANGELOG
+
+## v0.0.5
+
+This release contains some fixes to logic of existing functionality.
+
+### New Features
+
+- Manage Users Bucket Metadata with GunDB
+- Track files mimetype. `UserStorage.addItems` request now requires specifying the files `mimeType`
+and `UserStorage.openFile` returns the files `mimeType` in its response object.
+
+### New Fixes
+
+- Fix `UserStorage.listDirectory`'s response to have compatible `date` and `address` fields.

--- a/etc/sdk.api.md
+++ b/etc/sdk.api.md
@@ -89,7 +89,7 @@ export interface DirectoryEntry {
     // (undocumented)
     backupCount: number;
     // (undocumented)
-    created: Date;
+    created: string;
     // (undocumented)
     fileExtension: string;
     // (undocumented)
@@ -113,7 +113,7 @@ export interface DirectoryEntry {
     // (undocumented)
     sizeInBytes: number;
     // (undocumented)
-    updated: Date;
+    updated: string;
 }
 
 // @public (undocumented)
@@ -145,6 +145,9 @@ export class FileStorage {
     // (undocumented)
     remove(key: string): Promise<void>;
     }
+
+// @public (undocumented)
+export const GetAddressFromPublicKey: (pubkey: string) => string;
 
 // @public
 export class GunsdbMetadataStore implements UserMetadataStore {

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.4",
+  "version": "0.0.5",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/sdk",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Space SDK Library",
   "main": "dist/index",
   "types": "dist/index",
@@ -33,7 +33,7 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
-    "@spacehq/storage": "^0.0.4",
-    "@spacehq/users": "^0.0.4"
+    "@spacehq/storage": "^0.0.5",
+    "@spacehq/users": "^0.0.5"
   }
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/storage",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Space storage implementation",
   "main": "dist/index",
   "types": "dist/index",
@@ -40,7 +40,7 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
-    "@spacehq/users": "^0.0.4",
+    "@spacehq/users": "^0.0.5",
     "@textile/crypto": "^2.0.0",
     "@textile/hub": "^4.1.0",
     "@textile/threads-id": "^0.4.0",

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/users",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Space users implementation",
   "main": "dist/index",
   "types": "dist/index",


### PR DESCRIPTION
# CHANGELOG

## v0.0.5

This release contains some fixes to the logic of existing functionality.

### New Features

- Manage Users Bucket Metadata with GunDB
- Track files mimetype. `UserStorage.addItems` request now requires specifying the files `mimeType`
and `UserStorage.openFile` returns the files `mimeType` in its response object.

### New Fixes

- Fix `UserStorage.listDirectory`'s response to have compatible `date` and `address` fields.
