### PR TITLE
Release: v0.0.6

### DIFF
--- a/changelogs/v0.0.6.md
+++ b/changelogs/v0.0.6.md
@@ -1,0 +1,21 @@
+# CHANGELOG
+
+## v0.0.6
+
+This release contains some new features and fixes to logic of existing functionality.
+
+### New Features
+
+- Features to file Uuid Management. Now `DirectoryEntry` has a `uuid` field. Check the response from `UserStorage.listDirectory`.
+  
+- New method [`UserStorage.openFileByUuid`](https://fleekhq.github.io/space-sdk/docs/sdk.userstorage.openfilebyuuid) can be used 
+  to open a file exclusively by its uuid. Note: uuid would throw an error if current SpaceUser is not authorized to access the file.
+  
+- New method [`UserStorage.txlSubscribe`]((https://fleekhq.github.io/space-sdk/docs/sdk.userstorage.txlsubscribe)) can be used to subcribe
+to textile bucket events as user interacts with their bucket.
+
+
+### New Fixes
+
+- More secure and privacy fix around users buckets. Now everyn users bucket has a different thread id.
+Making it more similar to space-daemon.

--- a/etc/sdk.api.md
+++ b/etc/sdk.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { Buckets } from '@textile/hub';
+import { Client } from '@textile/hub';
 import { IGunChainReference } from 'gun/types/chain';
 import { UserAuth } from '@textile/hub';
 
@@ -281,6 +282,34 @@ export interface TextileStorageAuth {
 }
 
 // @public (undocumented)
+export interface TxlSubscribeBucketEvent {
+    // (undocumented)
+    bucketName: string;
+    // (undocumented)
+    error?: Error;
+    // (undocumented)
+    status: 'success' | 'error';
+}
+
+// @public (undocumented)
+export type TxlSubscribeEventData = TxlSubscribeBucketEvent;
+
+// @public (undocumented)
+export type TxlSubscribeEventType = 'data' | 'error' | 'done';
+
+// @public (undocumented)
+export type TxlSubscribeListener = (data: TxlSubscribeEventData) => void;
+
+// @public (undocumented)
+export interface TxlSubscribeResponse {
+    // (undocumented)
+    off: (type: TxlSubscribeEventType, listener: TxlSubscribeListener) => void;
+    // (undocumented)
+    on: (type: TxlSubscribeEventType, listener: TxlSubscribeListener) => void;
+    once: (type: TxlSubscribeEventType, listener: TxlSubscribeListener) => void;
+}
+
+// @public (undocumented)
 export class UnauthenticatedError extends Error {
     constructor();
 }
@@ -323,9 +352,11 @@ export class UserStorage {
     constructor(user: SpaceUser, config?: UserStorageConfig);
     addItems(request: AddItemsRequest): Promise<AddItemsResponse>;
     createFolder(request: CreateFolderRequest): Promise<void>;
+    initListener(): Promise<void>;
     listDirectory(request: ListDirectoryRequest): Promise<ListDirectoryResponse>;
     openFile(request: OpenFileRequest): Promise<OpenFileResponse>;
     openFileByUuid(uuid: string): Promise<OpenUuidFileResponse>;
+    txlSubscribe(): Promise<TxlSubscribeResponse>;
     }
 
 // @public (undocumented)
@@ -335,6 +366,8 @@ export interface UserStorageConfig {
     metadataStoreInit?: (identity: Identity) => Promise<UserMetadataStore>;
     // (undocumented)
     textileHubAddress?: string;
+    // (undocumented)
+    threadsInit?: (auth: UserAuth) => Client;
 }
 
 // @public

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.5",
+  "version": "0.0.6",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/sdk",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Space SDK Library",
   "main": "dist/index",
   "types": "dist/index",
@@ -33,7 +33,7 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
-    "@spacehq/storage": "^0.0.5",
-    "@spacehq/users": "^0.0.5"
+    "@spacehq/storage": "^0.0.6",
+    "@spacehq/users": "^0.0.6"
   }
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/storage",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Space storage implementation",
   "main": "dist/index",
   "types": "dist/index",
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.13.0",
-    "@spacehq/users": "^0.0.5",
+    "@spacehq/users": "^0.0.6",
     "@textile/crypto": "^2.0.0",
     "@textile/hub": "^4.1.0",
     "@textile/threads-id": "^0.4.0",

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/users",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Space users implementation",
   "main": "dist/index",
   "types": "dist/index",


### PR DESCRIPTION
# CHANGELOG

## v0.0.6

This release contains some new features and fixes to logic of existing functionality.

### New Features

- Features to file Uuid Management. Now `DirectoryEntry` has a `uuid` field. Check the response from `UserStorage.listDirectory`.

- New method [`UserStorage.openFileByUuid`](https://fleekhq.github.io/space-sdk/docs/sdk.userstorage.openfilebyuuid) can be used 
  to open a file exclusively by its uuid. Note: uuid would throw an error if current SpaceUser is not authorized to access the file.

- New method [`UserStorage.txlSubscribe`]((https://fleekhq.github.io/space-sdk/docs/sdk.userstorage.txlsubscribe)) can be used to subcribe
to textile bucket events as user interacts with their bucket.


### New Fixes

- More secure and privacy fix around users buckets. Now everyn users bucket has a different thread id.
Making it more similar to space-daemon.