### PR TITLE
Feature/ch20491/txlsubscribe

### DIFF
--- a/integration_tests/storage_interactions.spec.ts
+++ b/integration_tests/storage_interactions.spec.ts
@@ -193,7 +193,6 @@ describe('Users storing data', () => {
     });
 
     await prom;
-    // expect(Buffer.from(actualBytes)).to.deep.equal(imageBytes);
     done();
   });
 });

--- a/integration_tests/storage_interactions.spec.ts
+++ b/integration_tests/storage_interactions.spec.ts
@@ -208,7 +208,7 @@ describe('Users storing data', () => {
       .to.eventually.be.rejectedWith(FileNotFoundError);
   }).timeout(TestsDefaultTimeout);
 
-  it('should subscribe to textile events', async (done) => {
+  it('should subscribe to textile events', async () => {
     const { user } = await authenticateAnonymousUser();
     const txtContent = 'Some manual text should be in the file';
 
@@ -218,7 +218,7 @@ describe('Users storing data', () => {
     const ee = await storage.txlSubscribe();
 
     const eventData = new Promise<TxlSubscribeEventData>((resolve) => {
-      ee.once('data', (d:TxlSubscribeEventData) => d);
+      ee.once('data', (d:TxlSubscribeEventData) => resolve(d));
     });
 
     const uploadResponse = await storage.addItems({
@@ -239,6 +239,5 @@ describe('Users storing data', () => {
 
     const data = await eventData;
     expect(data.bucketName).to.equal('personal');
-    done();
-  });
+  }).timeout(TestsDefaultTimeout);
 });

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -40,6 +40,7 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
+    "@improbable-eng/grpc-web": "^0.13.0",
     "@spacehq/users": "^0.0.5",
     "@textile/crypto": "^2.0.0",
     "@textile/hub": "^4.1.0",

--- a/packages/storage/src/listener/listener.ts
+++ b/packages/storage/src/listener/listener.ts
@@ -1,0 +1,47 @@
+import { Client, Update, ThreadID } from '@textile/hub';
+import { grpc } from '@improbable-eng/grpc-web';
+import ee from 'event-emitter';
+
+declare interface Bucket {
+  name: string;
+}
+
+export class Listener {
+  private listeners:Map<string, grpc.Request>;
+
+  private client:Client;
+
+  private emitters:ee.Emitter[];
+
+  public constructor(dbids:string[], client:Client) {
+    this.client = client;
+    this.listeners = new Map();
+    this.emitters = [];
+
+    dbids.forEach((dbid) => {
+      this.addListener(dbid);
+    });
+  }
+
+  public addListener(dbid:string):void {
+    if (this.listeners.has(dbid)) {
+      throw new Error('Thread listener already exists');
+    }
+
+    const callback = (update?: Update<Bucket>) => {
+      if (!update || !update.instance) return;
+      this.emitters.forEach((emitter) => {
+        emitter.emit('data', {
+          bucketName: update.instance?.name,
+        });
+      });
+    };
+
+    const listener = this.client.listen(ThreadID.fromString(dbid), [], callback);
+    this.listeners.set(dbid, listener);
+  }
+
+  public subscribe(emitter: ee.Emitter):void {
+    this.emitters.push(emitter);
+  }
+}

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -120,3 +120,24 @@ export interface AddItemsResponse {
   once: (type: AddItemsEventType, listener: AddItemsListener) => void;
   off: (type: AddItemsEventType, listener: AddItemsListener) => void;
 }
+
+export interface TxlSubscribeBucketEvent {
+  bucketName: string;
+  status: 'success' | 'error';
+  error?: Error;
+}
+
+export type TxlSubscribeEventData = TxlSubscribeBucketEvent;
+export type TxlSubscribeEventType = 'data' | 'error' | 'done';
+export type TxlSubscribeListener = (data: TxlSubscribeEventData) => void;
+
+export interface TxlSubscribeResponse {
+  on: (type: TxlSubscribeEventType, listener: TxlSubscribeListener) => void;
+  // DO I NEED THIS?
+  /**
+   * this function should only be used to listen for the `'done'` event, since the listener would only be called once.
+   * or else you could end up having functions leaking (unless you explicitly call the `off()` function).
+   */
+  // once: (type: AddItemsEventType, listener: AddItemsListener) => void;
+  // off: (type: AddItemsEventType, listener: AddItemsListener) => void;
+}

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -151,11 +151,10 @@ export type TxlSubscribeListener = (data: TxlSubscribeEventData) => void;
 
 export interface TxlSubscribeResponse {
   on: (type: TxlSubscribeEventType, listener: TxlSubscribeListener) => void;
-  // DO I NEED THIS?
   /**
    * this function should only be used to listen for the `'done'` event, since the listener would only be called once.
    * or else you could end up having functions leaking (unless you explicitly call the `off()` function).
    */
   once: (type: TxlSubscribeEventType, listener: TxlSubscribeListener) => void;
-  // off: (type: TxlSubscribeEventType, listener: AddItemsListener) => void;
+  off: (type: TxlSubscribeEventType, listener: TxlSubscribeListener) => void;
 }

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -138,6 +138,6 @@ export interface TxlSubscribeResponse {
    * this function should only be used to listen for the `'done'` event, since the listener would only be called once.
    * or else you could end up having functions leaking (unless you explicitly call the `off()` function).
    */
-  // once: (type: AddItemsEventType, listener: AddItemsListener) => void;
-  // off: (type: AddItemsEventType, listener: AddItemsListener) => void;
+  once: (type: TxlSubscribeEventType, listener: TxlSubscribeListener) => void;
+  // off: (type: TxlSubscribeEventType, listener: AddItemsListener) => void;
 }

--- a/packages/storage/src/userStorage.ts
+++ b/packages/storage/src/userStorage.ts
@@ -174,6 +174,7 @@ export class UserStorage {
    * @example
    * ```typescript
    * const spaceStorage = new UserStorage(spaceUser);
+   * await spaceStorage.initListener();
    *
    * const response = await spaceStorage.txlSubscribe();
    *
@@ -522,9 +523,7 @@ export class UserStorage {
 
     // note: if initListener is not call, this won't
     // be registered
-    if (this.listener) {
-      this.listener.addListener(metadata.dbId);
-    }
+    this.listener?.addListener(metadata.dbId);
 
     return { ...metadata, ...getOrCreateResponse };
   }


### PR DESCRIPTION
## Description
This work creates the listener class which can be used to listen to multiple threads.  Any subscriber added to it will get events. A client can call `TxlSubscribe` to get back an event emitter that will give the thread change events.

IMPORTANT: you must call `await storage.initListener` before being able to use the `TxlSubscribe` function since the listener needs await to init.

Fixes # (issue)
https://app.clubhouse.io/terminalsystems/story/20491/txlsubscribe

## Type of change
<!--
Please delete options that are not relevant.
-->

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tech debt: need to add more tests but pushing this so we can release (integration test is working).

- [ ] Unit Test
- [x] Integration Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
