### PR TITLE
Hotfix: add dbid and bucket to directory entry.

### DIFF
--- a/integration_tests/storage_interactions.spec.ts
+++ b/integration_tests/storage_interactions.spec.ts
@@ -34,6 +34,9 @@ describe('Users storing data', () => {
       },
     ]);
 
+    expect(listFolder.items[0].dbId).to.not.be.empty;
+    expect(listFolder.items[0].bucket).to.not.be.empty;
+
     // validate empty .keep file is at folders root
     const fileResponse = await storage.openFile({ bucket: 'personal', path: '/topFolder/.keep' });
     const keepFilesContent = await fileResponse.consumeStream();
@@ -111,6 +114,8 @@ describe('Users storing data', () => {
         isDir: true,
       },
     ]);
+    expect(listFolder.items[0].bucket).to.not.be.empty;
+    expect(listFolder.items[0].dbId).to.not.be.empty;
 
     const listFolder1 = await storage.listDirectory({ bucket: 'personal', path: 'firstfolder', recursive: false });
     expect(listFolder1).to.not.be.equals(null);
@@ -194,8 +199,12 @@ describe('Users storing data', () => {
     const file = listFolder.items.find((item: DirectoryEntry) => item.name.includes('top.txt'));
     expect(file).to.not.be.undefined;
     expect(file?.uuid).to.not.be.empty;
+    expect(file?.bucket).to.not.be.empty;
+    expect(file?.dbId).to.not.be.empty;
 
     const fileResponse = await storage.openFileByUuid(file?.uuid || '');
+    expect(fileResponse?.entry?.bucket).to.not.be.empty;
+    expect(fileResponse?.entry?.dbId).to.not.be.empty;
     expect(fileResponse.entry.name).to.equal('top.txt');
     const actualTxtContent = await fileResponse.consumeStream();
     expect(new TextDecoder('utf8').decode(actualTxtContent)).to.equal(txtContent);

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -52,6 +52,8 @@ export interface DirectoryEntry {
   isRestoreInProgress: boolean;
   uuid: string;
   items?: DirectoryEntry[];
+  bucket:string;
+  dbId: string;
 }
 
 export interface ListDirectoryResponse {

--- a/packages/storage/src/userStorage.spec.ts
+++ b/packages/storage/src/userStorage.spec.ts
@@ -50,10 +50,10 @@ const initStubbedStorage = (): { storage: UserStorage; mockBuckets: Buckets } =>
     },
     {
       bucketsInit: () => instance(mockBuckets),
-      metadataStoreInit: async (): Promise<UserMetadataStore> => {
+      metadataStoreInit: async (): Promise<UserMetadataStore> =>
         // commenting this out now because it causes test to silently fail
         // return instance(mockMetadataStore); // to be fixed later
-        return Promise.resolve({
+        Promise.resolve({
           createBucket(bucketSlug: string, dbId: string): Promise<BucketMetadata> {
             return Promise.resolve({
               slug: 'myBucketKey',
@@ -85,8 +85,8 @@ const initStubbedStorage = (): { storage: UserStorage; mockBuckets: Buckets } =>
               path: '/',
             });
           },
-        });
-      },
+        })
+      ,
     },
   );
 
@@ -170,6 +170,8 @@ describe('UserStorage', () => {
       expect(result).to.not.equal(undefined);
       expect(result.items[0]).to.not.equal(undefined);
       expect(result.items[0].name).to.equal(childItem.name);
+      expect(result.items[0].bucket).to.not.be.empty;
+      expect(result.items[0].dbId).to.not.be.empty;
       expect(result.items[0].ipfsHash).to.equal(childItem.cid);
       expect(result.items[0].isDir).to.equal(childItem.isDir);
       expect(result.items[0].sizeInBytes).to.equal(childItem.size);
@@ -260,6 +262,8 @@ describe('UserStorage', () => {
 
       expect(new TextDecoder('utf8').decode(filesData)).to.equal(actualFileContent);
       expect(result.mimeType).to.equal('generic/type');
+      expect(result.entry.bucket).to.not.be.empty;
+      expect(result.entry.dbId).to.not.be.empty;
     });
   });
 


### PR DESCRIPTION
## Description
Adds `dbId` and `bucket` to the `DirectoryEntry` type so it is returned as well.

Fixes # (issue)
Reported on slack by @gpuente 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit Test
- [x] Integration Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
