### PR TITLE
Feature: Add DirectoryEntry to addItems results

### DIFF
--- a/etc/sdk.api.md
+++ b/etc/sdk.api.md
@@ -54,6 +54,8 @@ export interface AddItemsResultSummary {
 // @public (undocumented)
 export interface AddItemsStatus {
     // (undocumented)
+    entry?: DirectoryEntry;
+    // (undocumented)
     error?: Error;
     // (undocumented)
     path: string;

--- a/integration_tests/fixtures/configs.ts
+++ b/integration_tests/fixtures/configs.ts
@@ -17,4 +17,4 @@ export const TestUsersConfig: UsersConfig = {
   },
 };
 
-export const TestsDefaultTimeout = 100000; // 100s
+export const TestsDefaultTimeout = 500000; // 500s

--- a/integration_tests/storage_interactions.spec.ts
+++ b/integration_tests/storage_interactions.spec.ts
@@ -82,10 +82,18 @@ describe('Users storing data', () => {
         {
           path: '/subfolder/inner.txt',
           status: 'success',
+          entry: {
+            name: 'inner.txt',
+            isDir: false,
+          },
         },
         {
           path: '/subfolder',
           status: 'success',
+          entry: {
+            name: 'subfolder',
+            isDir: true,
+          },
         },
       ],
     });

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -119,6 +119,13 @@ export interface AddItemsRequest {
 export interface AddItemsStatus {
   path: string;
   status: 'success' | 'error';
+  /**
+   * Directory entry of uploaded file.
+   *
+   * Only present if status is 'success'.
+   *
+   */
+  entry?: DirectoryEntry;
   error?: Error;
 }
 

--- a/packages/storage/src/userStorage.spec.ts
+++ b/packages/storage/src/userStorage.spec.ts
@@ -274,6 +274,32 @@ describe('UserStorage', () => {
       when(mockBuckets.pushPath('myBucketKey', anyString(), anything())).thenResolve({
         ...mock<PushPathResult>(),
       });
+
+      const childItem = {
+        name: 'entryName',
+        path: '/ipfs/Qm123/entryName',
+        cid: 'Qm...',
+        isDir: false,
+        size: 10,
+      };
+
+      when(mockBuckets.listPath('myBucketKey', anyString())).thenResolve({
+        item: {
+          ...mock<PathItem>(),
+          name: 'entryName',
+          path: '/ipfs/Qm123/entryName',
+          cid: 'Qm...',
+          isDir: false,
+          size: 10,
+          metadata: {
+            updatedAt: (new Date().getMilliseconds()) * 1000000,
+            roles: new Map<string, PathAccessRole>(),
+          },
+          count: 0,
+          items: [],
+        },
+      });
+
       // fail upload of b.txt
       when(mockBuckets.pushPath('myBucketKey', '/b.txt', anything())).thenReject(uploadError);
       const callbackData = {


### PR DESCRIPTION
## Description
Fetch and add DirectoryEntry to addItems results

Fixes: ch21233

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit Test
- [ ] Integration Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
