### PR TITLE
Feature: Add upload callback and Add Blob to AddFileItem.data types

### DIFF
--- a/etc/sdk.api.md
+++ b/etc/sdk.api.md
@@ -12,9 +12,10 @@ import { UserAuth } from '@textile/hub';
 // @public (undocumented)
 export interface AddItemFile {
     // (undocumented)
-    data: ReadableStream<Uint8Array> | ArrayBuffer | string;
+    data: ReadableStream<Uint8Array> | ArrayBuffer | string | Blob;
     mimeType: string;
     path: string;
+    progress?: (bytesRead?: number) => void;
 }
 
 // @public (undocumented)

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -124,7 +124,13 @@ export interface AddItemFile {
    *
    */
   mimeType: string;
-  data: ReadableStream<Uint8Array> | ArrayBuffer | string;
+  data: ReadableStream<Uint8Array> | ArrayBuffer | string | Blob;
+  /**
+   * progress callback if provided will be called with bytes written to
+   * remote while uploading the file.
+   *
+   */
+  progress?: (bytesRead?: number) => void;
 }
 
 export interface AddItemsRequest {

--- a/packages/storage/src/userStorage.spec.ts
+++ b/packages/storage/src/userStorage.spec.ts
@@ -271,7 +271,7 @@ describe('UserStorage', () => {
     it('should publish data, error and done events correctly', async () => {
       const { storage, mockBuckets } = initStubbedStorage();
       const uploadError = new Error('update is non-fast-forward');
-      when(mockBuckets.pushPath('myBucketKey', anyString(), anything())).thenResolve({
+      when(mockBuckets.pushPath('myBucketKey', anyString(), anything(), anything())).thenResolve({
         ...mock<PushPathResult>(),
       });
 
@@ -301,7 +301,7 @@ describe('UserStorage', () => {
       });
 
       // fail upload of b.txt
-      when(mockBuckets.pushPath('myBucketKey', '/b.txt', anything())).thenReject(uploadError);
+      when(mockBuckets.pushPath('myBucketKey', '/b.txt', anything(), anything())).thenReject(uploadError);
       const callbackData = {
         data: [] as AddItemsEventData[],
         error: [] as AddItemsEventData[],

--- a/packages/storage/src/userStorage.ts
+++ b/packages/storage/src/userStorage.ts
@@ -483,7 +483,6 @@ export class UserStorage {
         };
 
         try {
-          await client.pushPath(rootKey, path, file.data);
           const metadata = await metadataStore.upsertFileMetadata({
             uuid: v4(),
             mimeType: file.mimeType,
@@ -491,6 +490,7 @@ export class UserStorage {
             dbId: bucket.dbId,
             path,
           });
+          await client.pushPath(rootKey, path, file.data, { progress: file.progress });
           // set file entry
           const existingFile = await client.listPath(rootKey, path);
           const [fileEntry] = UserStorage.parsePathItems(

--- a/packages/storage/src/utils/pathUtils.spec.ts
+++ b/packages/storage/src/utils/pathUtils.spec.ts
@@ -90,6 +90,10 @@ describe('pathUtils', () => {
         input: '/ipfs/bafybeifyipelgeu75bzjnrw5l5xpp4nmllh3owzk5o7qci7gtatstgdoam/top.txt',
         output: '/top.txt',
       },
+      {
+        input: '/ipfs/bafybeifyipelgeu75bzjnrw5l5xpp4nmllh3owzk5o7qci7gtatstgdoam/folder/top.txt',
+        output: '/folder/top.txt',
+      },
     ];
 
     // eslint-disable-next-line mocha/no-setup-in-describe


### PR DESCRIPTION
## Description
- Adds `Blob` as one of the supported types for uploading a file
- Adds an upload callback for `UserStorage.addItems()`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Unit Test
- [x] Integration Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
