### PR TITLE
Release: v0.0.10

### DIFF
--- a/changelogs/v0.0.10.md
+++ b/changelogs/v0.0.10.md
@@ -1,0 +1,13 @@
+# CHANGELOG
+
+## v0.0.10
+
+This release contains some new features and breaking changes to logic of existing functionality.
+
+### New Features
+
+No new features
+
+### New Fixes
+
+- Default hub address is now production value, and correctly overriding the config

--- a/changelogs/v0.0.10.md
+++ b/changelogs/v0.0.10.md
@@ -2,7 +2,7 @@
 
 ## v0.0.10
 
-This release contains some new features and breaking changes to logic of existing functionality.
+This release contains a fix with breaking changes.
 
 ### New Features
 

--- a/integration_tests/storage_interactions.spec.ts
+++ b/integration_tests/storage_interactions.spec.ts
@@ -110,6 +110,14 @@ describe('Users storing data', () => {
       ],
     });
 
+    let summary2: AddItemsResultSummary | undefined;
+    await new Promise((resolve) => {
+      anotheruploadResponse.once('done', (data: AddItemsEventData) => {
+        summary2 = data as AddItemsResultSummary;
+        resolve();
+      });
+    });
+
     // validate files are in the directory
     const listFolder = await storage.listDirectory({ bucket: 'personal', path: '' });
     expect(listFolder.items).to.containSubset([

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.9",
+  "version": "0.0.10",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/sdk",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Space SDK Library",
   "main": "dist/index",
   "types": "dist/index",
@@ -33,7 +33,7 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
-    "@spacehq/storage": "^0.0.9",
-    "@spacehq/users": "^0.0.9"
+    "@spacehq/storage": "^0.0.10",
+    "@spacehq/users": "^0.0.10"
   }
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/storage",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Space storage implementation",
   "main": "dist/index",
   "types": "dist/index",
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.13.0",
-    "@spacehq/users": "^0.0.9",
+    "@spacehq/users": "^0.0.10",
     "@textile/crypto": "^2.0.0",
     "@textile/hub": "^4.1.0",
     "@textile/threads-id": "^0.4.0",

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/users",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Space users implementation",
   "main": "dist/index",
   "types": "dist/index",


### PR DESCRIPTION
# CHANGELOG

## v0.0.10

This release contains a fix with breaking changes.

### New Features

No new features

### New Fixes

- Default hub address is now production value, and correctly overriding the config
