### PR TITLE
Fix: Ensure consumeStream()'s underlying buffer matches data view

### DIFF
--- a/packages/storage/src/utils/streamUtils.ts
+++ b/packages/storage/src/utils/streamUtils.ts
@@ -5,7 +5,8 @@ export const consumeStream = async (iterator: AsyncIterable<Uint8Array>): Promis
   // eslint-disable-next-line no-restricted-syntax
   for await (const chunk of iterator) {
     if (bytesBuffer.length === 0) {
-      bytesBuffer = chunk;
+      bytesBuffer = new Uint8Array(chunk.byteLength);
+      bytesBuffer.set(chunk);
     } else {
       const extendedBuffer = new Uint8Array(chunk.length + bytesBuffer.length);
       extendedBuffer.set(bytesBuffer);


### PR DESCRIPTION
## Description
This PR fixes an issue where referencing the underlying buffer of the TypedArray returned from opening a file contains some extra noise. It does this by setting the initial data chunk through the typedarray set method instead of just assigning the typearray.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Unit tests pass and also tested via users interaction

- [x] Unit Test
- [ ] Integration Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
