### PR TITLE
Hotfix: add bucketKey to metadata, populate members properly.

### DIFF
--- a/packages/storage/src/metadata/gundbMetadataStore.spec.ts
+++ b/packages/storage/src/metadata/gundbMetadataStore.spec.ts
@@ -20,12 +20,13 @@ describe('GunsdbMetadataStore', () => {
   }
 
   it('should work', async () => {
+    const bucketKey = 'somekey';
     const bucket = 'personal';
     const dbId = 'something';
     const store = await GundbMetadataStore.fromIdentity(username, password);
 
     // test create bucket data
-    const newSchema = await store.createBucket(bucket, dbId);
+    const newSchema = await store.createBucket(bucketKey, bucket, dbId);
     expect(newSchema).to.containSubset({ dbId, slug: bucket });
 
     // eslint-disable-next-line no-unused-expressions

--- a/packages/storage/src/metadata/gundbMetadataStore.spec.ts
+++ b/packages/storage/src/metadata/gundbMetadataStore.spec.ts
@@ -26,7 +26,7 @@ describe('GunsdbMetadataStore', () => {
     const store = await GundbMetadataStore.fromIdentity(username, password);
 
     // test create bucket data
-    const newSchema = await store.createBucket(bucketKey, bucket, dbId);
+    const newSchema = await store.createBucket(bucket, dbId, bucketKey);
     expect(newSchema).to.containSubset({ dbId, slug: bucket });
 
     // eslint-disable-next-line no-unused-expressions

--- a/packages/storage/src/metadata/gundbMetadataStore.ts
+++ b/packages/storage/src/metadata/gundbMetadataStore.ts
@@ -139,7 +139,7 @@ export class GundbMetadataStore implements UserMetadataStore {
   /**
    * {@inheritDoc @spacehq/sdk#UserMetadataStore.createBucket}
    */
-  public async createBucket(bucketSlug: string, dbId: string): Promise<BucketMetadata> {
+  public async createBucket(bucketSlug: string, dbId: string, bucketKey: string): Promise<BucketMetadata> {
     // throw if dbId with bucketSlug doesn't already
     const existingBucket = await this.findBucket(bucketSlug);
     if (existingBucket) {
@@ -150,6 +150,7 @@ export class GundbMetadataStore implements UserMetadataStore {
       dbId,
       encryptionKey: crypto.randomBytes(BucketEncryptionKeyLength),
       slug: bucketSlug,
+      bucketKey,
     };
     const encryptedMetadata = await this.encryptBucketSchema(schema);
     const lookupKey = this.getBucketsLookupKey(bucketSlug);

--- a/packages/storage/src/metadata/metadataStore.ts
+++ b/packages/storage/src/metadata/metadataStore.ts
@@ -10,8 +10,9 @@ export interface UserMetadataStore {
    *
    * @param bucketSlug - unqiue slug representing bucket provided by user.
    * @param dbId - unique id representing bucket provided by user storage.
+   * @param dbId - unique id representing bucket provided by user storage.
    */
-  createBucket: (bucketSlug: string, dbId: string) => Promise<BucketMetadata>;
+  createBucket: (bucketSlug: string, dbId: string, bucketKey: string) => Promise<BucketMetadata>;
 
   /**
    * Find bucket metadata with slug belonging to the current user matching
@@ -64,6 +65,10 @@ export interface UserMetadataStore {
  *
  */
 export interface BucketMetadata {
+  /**
+   * unique id that Textile uses internally for buckets
+   */
+  bucketKey: string;
   /**
    * unique user specified bucket slug
    */

--- a/packages/storage/src/metadata/metadataStore.ts
+++ b/packages/storage/src/metadata/metadataStore.ts
@@ -9,8 +9,8 @@ export interface UserMetadataStore {
    * It should fail if a bucketSlug with similar dbId already exists.
    *
    * @param bucketSlug - unqiue slug representing bucket provided by user.
-   * @param dbId - unique id representing bucket provided by user storage.
-   * @param dbId - unique id representing bucket provided by user storage.
+   * @param dbId - unique id representing bucket thread provided by user storage.
+   * @param bucketKey -  unique id representing bucket provided by user storage.
    */
   createBucket: (bucketSlug: string, dbId: string, bucketKey: string) => Promise<BucketMetadata>;
 

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -25,12 +25,20 @@ export interface ListDirectoryRequest {
   recursive?: boolean;
 }
 
+enum Roles {
+  NONE = 0,
+  READ,
+  WRITE,
+  ADMIN,
+}
+
 /**
  * Represents a member on a shared file
  */
 export interface FileMember {
   publicKey:string;
   address?:string;
+  role: Roles;
 }
 
 /**

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -1,3 +1,5 @@
+import { PathAccessRole } from '@textile/hub';
+
 export interface CreateFolderRequest {
   /**
    * Storage bucket to create the empty folder
@@ -25,20 +27,13 @@ export interface ListDirectoryRequest {
   recursive?: boolean;
 }
 
-enum Roles {
-  NONE = 0,
-  READ,
-  WRITE,
-  ADMIN,
-}
-
 /**
  * Represents a member on a shared file
  */
 export interface FileMember {
   publicKey:string;
   address?:string;
-  role: Roles;
+  role: PathAccessRole;
 }
 
 /**

--- a/packages/storage/src/userStorage.spec.ts
+++ b/packages/storage/src/userStorage.spec.ts
@@ -56,6 +56,7 @@ const initStubbedStorage = (): { storage: UserStorage; mockBuckets: Buckets } =>
         Promise.resolve({
           createBucket(bucketSlug: string, dbId: string): Promise<BucketMetadata> {
             return Promise.resolve({
+              bucketKey: 'testkey',
               slug: 'myBucketKey',
               encryptionKey: new Uint8Array(80),
               dbId: 'dbId',
@@ -63,6 +64,7 @@ const initStubbedStorage = (): { storage: UserStorage; mockBuckets: Buckets } =>
           },
           findBucket(bucketSlug: string): Promise<BucketMetadata | undefined> {
             return Promise.resolve({
+              bucketKey: 'testkey',
               slug: 'myBucketKey',
               encryptionKey: new Uint8Array(80),
               dbId: 'dbId',

--- a/packages/storage/src/userStorage.spec.ts
+++ b/packages/storage/src/userStorage.spec.ts
@@ -145,9 +145,6 @@ describe('UserStorage', () => {
         size: 10,
       };
 
-      const roles = new Map<string, PathAccessRole>();
-      const pubkey = 'bbaareieswor4fnmzdwmv6fwij2rxyyjmpc2izognkiqnfxlvnzzsvs7y5y';
-      roles.set(pubkey, PathAccessRole.PATH_ACCESS_ROLE_ADMIN);
       const updatedAt = (new Date().getMilliseconds()) * 1000000;
 
       const { storage, mockBuckets } = initStubbedStorage();
@@ -159,7 +156,7 @@ describe('UserStorage', () => {
               ...childItem,
               metadata: {
                 updatedAt,
-                roles,
+                roles: new Map(),
               },
               items: [],
               count: 1,
@@ -167,6 +164,11 @@ describe('UserStorage', () => {
           ],
         },
       });
+
+      const mockMembers = new Map<string, PathAccessRole>();
+      const pubkey = 'bbaareieswor4fnmzdwmv6fwij2rxyyjmpc2izognkiqnfxlvnzzsvs7y5y';
+      mockMembers.set(pubkey, PathAccessRole.PATH_ACCESS_ROLE_WRITER);
+      when(mockBuckets.pullPathAccessRoles(anyString(), anyString())).thenResolve(mockMembers);
 
       const result = await storage.listDirectory(listDirectoryRequest);
 
@@ -186,7 +188,8 @@ describe('UserStorage', () => {
       expect(result.items[0].isLocallyAvailable).to.equal(false);
       expect(result.items[0].backupCount).to.equal(1);
       expect(result.items[0].members).to.deep.equal([{
-        publicKey: Buffer.from(publicKeyBytesFromString(pubkey)).toString('hex'),
+        publicKey: pubkey,
+        role: PathAccessRole.PATH_ACCESS_ROLE_WRITER,
         address: GetAddressFromPublicKey(pubkey),
       }]);
       expect(result.items[0].isBackupInProgress).to.equal(false);
@@ -261,6 +264,10 @@ describe('UserStorage', () => {
       when(mockBuckets.pullPath('myBucketKey', anyString(), anything())).thenReturn(
         makeAsyncIterableString(actualFileContent) as AsyncIterableIterator<Uint8Array>,
       );
+
+      const mockMembers = new Map<string, PathAccessRole>();
+      mockMembers.set('dummykey', PathAccessRole.PATH_ACCESS_ROLE_WRITER);
+      when(mockBuckets.pullPathAccessRoles('myBucketKey', '/ipfs/Qm123/file.txt')).thenResolve(mockMembers);
 
       const result = await storage.openFileByUuid({ uuid: fileUuid });
       const filesData = await result.consumeStream();

--- a/packages/storage/src/userStorage.ts
+++ b/packages/storage/src/userStorage.ts
@@ -146,7 +146,7 @@ export class UserStorage {
         ms.forEach((v, k) => {
           members.push({
             publicKey: k,
-            address: key === '*' ? '' : GetAddressFromPublicKey(k),
+            address: k === '*' ? '' : GetAddressFromPublicKey(k),
             role: v,
           });
         });

--- a/packages/storage/src/userStorage.ts
+++ b/packages/storage/src/userStorage.ts
@@ -380,12 +380,12 @@ export class UserStorage {
       );
 
       const fileData = client.pullPath(bucketKey, fileMetadata.path, { progress: request.progress });
-
+      const [fileEntryWithmembers] = await UserStorage.addMembersToPathItems([fileEntry], client, metadataStore);
       return {
         stream: fileData,
         consumeStream: () => consumeStream(fileData),
         mimeType: fileMetadata.mimeType,
-        entry: fileEntry,
+        entry: fileEntryWithmembers,
       };
     } catch (e) {
       if (e.message.includes('no link named')) {
@@ -536,7 +536,8 @@ export class UserStorage {
             bucket.slug,
             bucket.dbId,
           );
-          status.entry = folderEntry;
+          const [folderEntryWithmembers] = await UserStorage.addMembersToPathItems([folderEntry], client, metadataStore);
+          status.entry = folderEntryWithmembers;
 
           emitter.emit('data', status);
           summary.files.push(status);
@@ -583,7 +584,10 @@ export class UserStorage {
             bucket.slug,
             bucket.dbId,
           );
-          status.entry = fileEntry;
+
+          const [fileEntryWithmembers] = await UserStorage.addMembersToPathItems([fileEntry], client, metadataStore);
+
+          status.entry = fileEntryWithmembers;
 
           emitter.emit('data', status);
         } catch (err) {

--- a/packages/storage/src/userStorage.ts
+++ b/packages/storage/src/userStorage.ts
@@ -139,19 +139,23 @@ export class UserStorage {
 
     for (let i = 0; i < newItems.length; i += 1) {
       const ms = await client.pullPathAccessRoles(key, newItems[i].path);
-      const members: FileMember[] = [];
 
-      ms.forEach((v, k) => {
-        members.push({
-          publicKey: k,
-          role: v,
+      if (ms) {
+        const members: FileMember[] = [];
+
+        ms.forEach((v, k) => {
+          members.push({
+            publicKey: k,
+            address: key === '*' ? '' : GetAddressFromPublicKey(k),
+            role: v,
+          });
         });
-      });
 
-      newItems[i].members = members;
+        newItems[i].members = members;
 
-      if ((newItems[i]?.items?.length || 0) > 0) {
-        newItems[i].items = await this.addMembersToPathItems(newItems[i].items as DirectoryEntry[], client, store, key);
+        if ((newItems[i]?.items?.length || 0) > 0) {
+          newItems[i].items = await this.addMembersToPathItems(newItems[i].items as DirectoryEntry[], client, store, key);
+        }
       }
     }
 


### PR DESCRIPTION
## Description
Add bucketKey to metadata, populate members properly. NOTE: the originally expected metadata field on Textile's `ListPath` response is not returning the members. So this work around calls `PullPathAccessRoles` explicitly to retrieve members. We should still follow up with Textile and if we can get that data returned, we don't have to do this N+1 querying.

Fixes (issue): Unable to retrieve members.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Unit Test
- [x] Integration Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
