### PR TITLE
Release v0.0.15

### DIFF
--- a/changelogs/v0.0.15.md
+++ b/changelogs/v0.0.15.md
@@ -1,0 +1,7 @@
+# CHANGELOG
+
+## v0.0.15
+
+This release contains a bug fix and is not backwards compatible due to upgrades to the metadata schema.
+
+- The members field is actually populated now in `DirectoryEntry` items and also includes the `role` field

--- a/etc/sdk.api.md
+++ b/etc/sdk.api.md
@@ -7,6 +7,7 @@
 import { Buckets } from '@textile/hub';
 import { Client } from '@textile/hub';
 import { IGunChainReference } from 'gun/types/chain';
+import { PathAccessRole } from '@textile/hub';
 import Pino from 'pino';
 import { UserAuth } from '@textile/hub';
 
@@ -77,6 +78,7 @@ export class BrowserStorage {
 
 // @public
 export interface BucketMetadata {
+    bucketKey: string;
     dbId: string;
     encryptionKey: Uint8Array;
     slug: string;
@@ -137,6 +139,8 @@ export interface FileMember {
     address?: string;
     // (undocumented)
     publicKey: string;
+    // (undocumented)
+    role: PathAccessRole;
 }
 
 // @public
@@ -176,7 +180,7 @@ export const GetAddressFromPublicKey: (pubkey: string) => string;
 
 // @public
 export class GundbMetadataStore implements UserMetadataStore {
-    createBucket(bucketSlug: string, dbId: string): Promise<BucketMetadata>;
+    createBucket(bucketSlug: string, dbId: string, bucketKey: string): Promise<BucketMetadata>;
     findBucket(bucketSlug: string): Promise<BucketMetadata | undefined>;
     findFileMetadata(bucketSlug: string, dbId: string, path: string): Promise<FileMetadata | undefined>;
     findFileMetadataByUuid(uuid: string): Promise<FileMetadata | undefined>;
@@ -342,7 +346,7 @@ export class UnauthenticatedError extends Error {
 
 // @public
 export interface UserMetadataStore {
-    createBucket: (bucketSlug: string, dbId: string) => Promise<BucketMetadata>;
+    createBucket: (bucketSlug: string, dbId: string, bucketKey: string) => Promise<BucketMetadata>;
     findBucket: (bucketSlug: string) => Promise<BucketMetadata | undefined>;
     findFileMetadata: (bucketSlug: string, dbId: string, path: string) => Promise<FileMetadata | undefined>;
     findFileMetadataByUuid: (uuid: string) => Promise<FileMetadata | undefined>;

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.14",
+  "version": "0.0.15",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/sdk",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Space SDK Library",
   "main": "dist/index",
   "types": "dist/index",
@@ -33,7 +33,7 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
-    "@spacehq/storage": "^0.0.14",
-    "@spacehq/users": "^0.0.14"
+    "@spacehq/storage": "^0.0.15",
+    "@spacehq/users": "^0.0.15"
   }
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/storage",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Space storage implementation",
   "main": "dist/index",
   "types": "dist/index",
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.13.0",
-    "@spacehq/users": "^0.0.14",
+    "@spacehq/users": "^0.0.15",
     "@textile/crypto": "^2.0.0",
     "@textile/hub": "^4.1.0",
     "@textile/threads-id": "^0.4.0",

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/users",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Space users implementation",
   "main": "dist/index",
   "types": "dist/index",


### PR DESCRIPTION
# CHANGELOG

## v0.0.15

This release contains a bug fix and is not backwards compatible due to upgrades to the metadata schema.

- The members field is actually populated now in `DirectoryEntry` items and also includes the `role` field