### PR TITLE
Hotfix: init if mailbox is not set

### DIFF
--- a/integration_tests/fixtures/configs.ts
+++ b/integration_tests/fixtures/configs.ts
@@ -19,7 +19,7 @@ export const TestUsersConfig: UsersConfig = {
 
 export const TestsDefaultTimeout = 500000; // 500s
 
-const textileHubAddress = process.env.TXL_HUB_URL;
+const textileHubAddress = process.env.TXL_HUB_URL || '';
 
 export const TestStorageConfig: UserStorageConfig = {
   textileHubAddress,

--- a/integration_tests/fixtures/configs.ts
+++ b/integration_tests/fixtures/configs.ts
@@ -1,4 +1,4 @@
-import { UsersConfig } from '@spacehq/sdk';
+import { UsersConfig, UserStorageConfig } from '@spacehq/sdk';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 require('dotenv').config({
@@ -18,3 +18,9 @@ export const TestUsersConfig: UsersConfig = {
 };
 
 export const TestsDefaultTimeout = 500000; // 500s
+
+const textileHubAddress = process.env.TXL_HUB_URL;
+
+export const TestStorageConfig: UserStorageConfig = {
+  textileHubAddress,
+};

--- a/integration_tests/fixtures/configs.ts
+++ b/integration_tests/fixtures/configs.ts
@@ -19,7 +19,7 @@ export const TestUsersConfig: UsersConfig = {
 
 export const TestsDefaultTimeout = 500000; // 500s
 
-const textileHubAddress = process.env.TXL_HUB_URL || '';
+const textileHubAddress = process.env.TXL_HUB_URL;
 
 export const TestStorageConfig: UserStorageConfig = {
   textileHubAddress,

--- a/integration_tests/mailbox_interactions.spec.ts
+++ b/integration_tests/mailbox_interactions.spec.ts
@@ -1,7 +1,7 @@
 import { Mailbox, tryParsePublicKey } from '@spacehq/sdk';
 import { expect, use } from 'chai';
 import * as chaiSubset from 'chai-subset';
-import { TestsDefaultTimeout, TestUsersConfig } from './fixtures/configs';
+import { TestsDefaultTimeout, TestStorageConfig } from './fixtures/configs';
 import { authenticateAnonymousUser } from './helpers/userHelper';
 
 use(chaiSubset.default);
@@ -9,15 +9,15 @@ use(chaiSubset.default);
 describe('Mailbox interactions', () => {
   it('should be able to setup mailbox', async () => {
     const { user } = await authenticateAnonymousUser();
-    const mb = await Mailbox.createMailbox(user);
+    const mb = await Mailbox.createMailbox(user, TestStorageConfig);
   }).timeout(TestsDefaultTimeout);
 
   it('should be able to send a mail', async () => {
     const { user: user1 } = await authenticateAnonymousUser();
-    const mb1 = await Mailbox.createMailbox(user1);
+    const mb1 = await Mailbox.createMailbox(user1, TestStorageConfig);
 
     const { user: user2, identity: receipient } = await authenticateAnonymousUser();
-    const mb2 = await Mailbox.createMailbox(user2);
+    const mb2 = await Mailbox.createMailbox(user2, TestStorageConfig);
 
     const sentmsg = await mb1.sendMessage(Buffer.from(user2.identity.public.pubKey).toString('hex'), new Uint8Array(8));
 

--- a/integration_tests/storage_interactions.spec.ts
+++ b/integration_tests/storage_interactions.spec.ts
@@ -12,7 +12,7 @@ import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as chaiSubset from 'chai-subset';
 import path from 'path';
-import { TestsDefaultTimeout } from './fixtures/configs';
+import { TestsDefaultTimeout, TestStorageConfig } from './fixtures/configs';
 import { authenticateAnonymousUser } from './helpers/userHelper';
 
 use(chaiAsPromised.default);
@@ -22,7 +22,7 @@ describe('Users storing data', () => {
   it('user should create an empty folder successfully', async () => {
     const { user } = await authenticateAnonymousUser();
 
-    const storage = new UserStorage(user);
+    const storage = new UserStorage(user, TestStorageConfig);
     await storage.createFolder({ bucket: 'personal', path: 'topFolder' });
 
     // verify folder is added
@@ -47,7 +47,7 @@ describe('Users storing data', () => {
     const { user } = await authenticateAnonymousUser();
     const txtContent = 'Some manual text should be in the file';
 
-    const storage = new UserStorage(user);
+    const storage = new UserStorage(user, TestStorageConfig);
     const uploadResponse = await storage.addItems({
       bucket: 'personal',
       files: [
@@ -167,7 +167,7 @@ describe('Users storing data', () => {
 
     const { user } = await authenticateAnonymousUser();
     const imageBytes = fs.readFileSync(path.join(__dirname, 'test_data', 'image.jpg'));
-    const storage = new UserStorage(user);
+    const storage = new UserStorage(user, TestStorageConfig);
     const uploadResponse = await storage.addItems({
       bucket: 'personal',
       files: [
@@ -196,7 +196,7 @@ describe('Users storing data', () => {
     const { user } = await authenticateAnonymousUser();
     const txtContent = 'Some manual text should be in the file';
 
-    const storage = new UserStorage(user);
+    const storage = new UserStorage(user, TestStorageConfig);
     const uploadResponse = await storage.addItems({
       bucket: 'personal',
       files: [
@@ -229,7 +229,7 @@ describe('Users storing data', () => {
 
     // ensure file is not accessible from outside of owners file
     const { user: unauthorizedUser } = await authenticateAnonymousUser();
-    const unauthorizedStorage = new UserStorage(unauthorizedUser);
+    const unauthorizedStorage = new UserStorage(unauthorizedUser, TestStorageConfig);
 
     await expect(unauthorizedStorage.openFileByUuid({ uuid: file?.uuid || '' }))
       .to.eventually.be.rejectedWith(FileNotFoundError);
@@ -249,7 +249,7 @@ describe('Users storing data', () => {
     const { user } = await authenticateAnonymousUser();
     const txtContent = 'Some manual text should be in the file';
 
-    const storage = new UserStorage(user);
+    const storage = new UserStorage(user, TestStorageConfig);
     await storage.initListener();
 
     const ee = await storage.txlSubscribe();

--- a/integration_tests/test.env
+++ b/integration_tests/test.env
@@ -5,5 +5,3 @@
 HUB_AUTH_ENDPOINT=hub-ws-auth-endpoint
 VAULT_API_URL=https://vault_service_api_url.com
 VAULT_SALT_SECRET=vault-secret
-# only needed if using a non-prod env
-TXL_HUB_URL=https://hub-url

--- a/integration_tests/test.env
+++ b/integration_tests/test.env
@@ -6,4 +6,4 @@ HUB_AUTH_ENDPOINT=hub-ws-auth-endpoint
 VAULT_API_URL=https://vault_service_api_url.com
 VAULT_SALT_SECRET=vault-secret
 # only needed if using a non-prod env
-TXL_HUB_URL=https://hub-url
+# TXL_HUB_URL=https://hub-url

--- a/integration_tests/test.env
+++ b/integration_tests/test.env
@@ -5,3 +5,5 @@
 HUB_AUTH_ENDPOINT=hub-ws-auth-endpoint
 VAULT_API_URL=https://vault_service_api_url.com
 VAULT_SALT_SECRET=vault-secret
+# only needed if using a non-prod env
+TXL_HUB_URL=https://hub-url

--- a/integration_tests/users_interactions.spec.ts
+++ b/integration_tests/users_interactions.spec.ts
@@ -1,7 +1,7 @@
 import { BrowserStorage, Users, UserStorage, VaultBackupType } from '@spacehq/sdk';
 import { expect, use } from 'chai';
 import * as chaiSubset from 'chai-subset';
-import { TestsDefaultTimeout, TestUsersConfig } from './fixtures/configs';
+import { TestsDefaultTimeout, TestUsersConfig, TestStorageConfig } from './fixtures/configs';
 import { authenticateAnonymousUser } from './helpers/userHelper';
 
 use(chaiSubset.default);
@@ -60,7 +60,7 @@ describe('Users interactions', () => {
       const backupType = VaultBackupType.Twitter;
 
       // Perform some data storage with user
-      const storage = new UserStorage(user);
+      const storage = new UserStorage(user, TestStorageConfig);
       await storage.createFolder({
         bucket: 'personal',
         path: '/newFolder',
@@ -74,7 +74,7 @@ describe('Users interactions', () => {
       expect(recoveredUser.identity.public.toString()).to.equal(user.identity.public.toString());
 
       // verify recovered user still has existing storage data
-      const recoveredUsersStorage = new UserStorage(recoveredUser);
+      const recoveredUsersStorage = new UserStorage(recoveredUser, TestStorageConfig);
       const directories = await recoveredUsersStorage.listDirectory({
         bucket: 'personal',
         path: '',

--- a/packages/storage/src/userStorage.ts
+++ b/packages/storage/src/userStorage.ts
@@ -756,6 +756,10 @@ export class UserStorage {
    *
    */
   public async getNotifications(seek?: string, limit?:number): Promise<GetNotificationsResponse> {
+    if (!this.mailbox) {
+      await this.initMailbox();
+    }
+
     const msgs = await this.mailbox?.listInboxMessages(seek, limit);
     const notifs:Notification[] = [];
     const lastSeenAt = new Date().getTime();
@@ -947,6 +951,10 @@ export class UserStorage {
       filteredRecipients,
       store,
     );
+
+    if (!this.mailbox) {
+      await this.initMailbox();
+    }
 
     // eslint-disable-next-line no-restricted-syntax
     for (const inv of invitations) {


### PR DESCRIPTION
## Description
This change double checks if the mailbox field is set on the SDK and init's it if it is not found.  Even though the FE was initalizing it, for some reason the mailbox field was null so it was not sending the mails. This is a workaround so it re-inits it.  @perfectmak let me know if you spot anything that could be the underlying issue.

Sidenote: also updated integration tests so we can test on dev via env vars as needed.

Fixes # (issue)
Mail not sending during share.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- [x] Unit Test
- [x] Integration Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
