### PR TITLE
Hotfix: empty pk should not fail overall share. 

### DIFF
--- a/packages/storage/src/userStorage.ts
+++ b/packages/storage/src/userStorage.ts
@@ -1051,7 +1051,7 @@ export class UserStorage {
     const idString = Buffer.from(this.user.identity.public.pubKey).toString('hex');
     const filteredRecipients: string[] = request.publicKeys
       .map((key) => key.pk)
-      .filter((key) => key !== null && key !== undefined) as string[];
+      .filter((key) => !!key) as string[];
     const store = await this.getMetadataStore();
 
     const invitations = await createFileInvitations(


### PR DESCRIPTION
## Description
Fixes issue where empty pub key fails the overall share because we need to filter on empty strings as well. 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] Unit Test
- [x] Integration Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
