### PR TITLE
Release v0.0.22

### DIFF
--- a/changelogs/v0.0.22.md
+++ b/changelogs/v0.0.22.md
@@ -1,0 +1,8 @@
+# CHANGELOG
+
+## v0.0.22
+
+Releases a bug fix:
+
+### Fixes
+- Fixes `shareViaPublicKey` so that empty public keys do not cause a throw

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.21",
+  "version": "0.0.22",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/mailbox/package.json
+++ b/packages/mailbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/mailbox",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Space Mailbox implementation",
   "main": "dist/index",
   "types": "dist/index",
@@ -37,7 +37,7 @@
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.14.0",
     "@spacehq/users": "^0.0.13",
-    "@spacehq/utils": "^0.0.21",
+    "@spacehq/utils": "^0.0.22",
     "@textile/crypto": "^2.0.0",
     "@types/lodash": "^4.14.165",
     "axios": "^0.21.1",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/sdk",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Space SDK Library",
   "main": "dist/index",
   "types": "dist/index",
@@ -33,9 +33,9 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
-    "@spacehq/mailbox": "^0.0.21",
-    "@spacehq/storage": "^0.0.21",
-    "@spacehq/users": "^0.0.21",
-    "@spacehq/utils": "^0.0.21"
+    "@spacehq/mailbox": "^0.0.22",
+    "@spacehq/storage": "^0.0.22",
+    "@spacehq/users": "^0.0.22",
+    "@spacehq/utils": "^0.0.22"
   }
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/storage",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Space storage implementation",
   "main": "dist/index",
   "types": "dist/index",
@@ -42,9 +42,9 @@
   },
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.13.0",
-    "@spacehq/mailbox": "^0.0.21",
-    "@spacehq/users": "^0.0.21",
-    "@spacehq/utils": "^0.0.21",
+    "@spacehq/mailbox": "^0.0.22",
+    "@spacehq/users": "^0.0.22",
+    "@spacehq/utils": "^0.0.22",
     "@textile/crypto": "^2.0.0",
     "@textile/hub": "^4.1.0",
     "@textile/threads-id": "^0.4.0",

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/users",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Space users implementation",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacehq/utils",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Space Common Utils",
   "main": "dist/index",
   "types": "dist/index",
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.14.0",
-    "@spacehq/users": "^0.0.21",
+    "@spacehq/users": "^0.0.22",
     "@textile/crypto": "^2.0.0",
     "@types/lodash": "^4.14.165",
     "axios": "^0.21.1",


### PR DESCRIPTION
# CHANGELOG

## v0.0.22

Releases a bug fix:

### Fixes
- Fixes `shareViaPublicKey` so that empty public keys do not cause a throw
