### PR TITLE
setNotificationsLastSeenAt and add the value to getNotifications call

### DIFF
--- a/integration_tests/sharing_interactions.spec.ts
+++ b/integration_tests/sharing_interactions.spec.ts
@@ -70,6 +70,9 @@ describe('Users sharing data', () => {
       // ... // verify address and role too
     }]);
 
+    const ts = Date.now();
+    await storage2.setNotificationsLastSeenAt(ts);
+
     // verify user2 get notification
     const received = await storage2.getNotifications();
     expect(received.notifications[0]).not.to.be.null;
@@ -86,6 +89,7 @@ describe('Users sharing data', () => {
     expect(received.notifications[0].relatedObject?.itemPaths[0].dbId).not.to.be.null;
     expect(received.notifications[0].relatedObject?.itemPaths[0].bucketKey).not.to.be.null;
     expect(received.notifications[0].relatedObject?.keys[0]).not.to.be.null;
+    expect(received.lastSeenAt).to.equal(ts);
 
     // accept the notification
     await storage2.handleFileInvitation(received.notifications[0].id, true);

--- a/packages/storage/src/metadata/gundbMetadataStore.spec.ts
+++ b/packages/storage/src/metadata/gundbMetadataStore.spec.ts
@@ -119,4 +119,15 @@ describe('GunsdbMetadataStore', () => {
     expect(sharedWithMeFiles).to.have.length(1);
     expect(sharedWithMeFiles[0]).to.deep.equal(sharedFileMetadata);
   }).timeout(TestTimeout);
+
+  it('should insert and retrieve last notifications seen at', async () => {
+    const store = await GundbMetadataStore.fromIdentity(username, password, undefined, false);
+
+    const ts = Date.now();
+    await store.setNotificationsLastSeenAt(ts);
+
+    const fetchedTs = await store.getNotificationsLastSeenAt();
+
+    expect(fetchedTs).to.equal(ts);
+  }).timeout(TestTimeout);
 });

--- a/packages/storage/src/metadata/gundbMetadataStore.ts
+++ b/packages/storage/src/metadata/gundbMetadataStore.ts
@@ -188,7 +188,7 @@ export class GundbMetadataStore implements UserMetadataStore {
    */
   public async setNotificationsLastSeenAt(timestamp: number): Promise<void> {
     const encryptedTimestamp = await this.encrypt(timestamp.toString());
-    const lookupKey = this.getNotificationsLastSeenAtLookupKey();
+    const lookupKey = GundbMetadataStore.getNotificationsLastSeenAtLookupKey();
     const nodeRef = this.lookupUser.get(lookupKey).put({ data: encryptedTimestamp });
   }
 
@@ -197,7 +197,7 @@ export class GundbMetadataStore implements UserMetadataStore {
    */
   public async getNotificationsLastSeenAt(): Promise<number> {
     this.logger?.info({ username: this.username }, 'Store.getNotificationsLastSeenAt');
-    const lookupKey = this.getNotificationsLastSeenAtLookupKey();
+    const lookupKey = GundbMetadataStore.getNotificationsLastSeenAtLookupKey();
     const res:number|undefined = await this.lookupUserData(lookupKey);
     return res || 0;
   }
@@ -498,8 +498,8 @@ export class GundbMetadataStore implements UserMetadataStore {
     });
   }
 
-  private getNotificationsLastSeenAtLookupKey(): string {
-    return `notifications/lastSeenAt`;
+  private static getNotificationsLastSeenAtLookupKey(): string {
+    return 'notifications/lastSeenAt';
   }
 
   private getBucketsLookupKey(bucketSlug: string): string {

--- a/packages/storage/src/metadata/gundbMetadataStore.ts
+++ b/packages/storage/src/metadata/gundbMetadataStore.ts
@@ -190,7 +190,6 @@ export class GundbMetadataStore implements UserMetadataStore {
     const encryptedTimestamp = await this.encrypt(timestamp.toString());
     const lookupKey = this.getNotificationsLastSeenAtLookupKey();
     const nodeRef = this.lookupUser.get(lookupKey).put({ data: encryptedTimestamp });
-    this.listUser.get(NotificationsLastSeenAtCollection).set(nodeRef as unknown as EncryptedMetadata);
   }
 
   /**
@@ -500,7 +499,7 @@ export class GundbMetadataStore implements UserMetadataStore {
   }
 
   private getNotificationsLastSeenAtLookupKey(): string {
-    return `notifications/lastSeenAt/${this.username}`;
+    return `notifications/lastSeenAt`;
   }
 
   private getBucketsLookupKey(bucketSlug: string): string {

--- a/packages/storage/src/metadata/gundbMetadataStore.ts
+++ b/packages/storage/src/metadata/gundbMetadataStore.ts
@@ -32,6 +32,7 @@ const BucketMetadataCollection = 'BucketMetadata';
 const SharedFileMetadataCollection = 'SharedFileMetadata';
 const SharedByMeFileMetadataCollection = 'SharedByMeFileMetadata';
 const RecentlySharedWithMetadataCollection = 'RecentlySharedWithMetadata';
+const NotificationsLastSeenAtCollection = 'NotificationsLastSeenAtMetadata';
 const PublicStoreUsername = '66f47ce32570335085b39bdf';
 const PublicStorePassword = '830a20694358651ef14e472fd71c4f9f843ecd50784b241a6c9999dba4c6fced0f90c686bdee28edc';
 
@@ -180,6 +181,26 @@ export class GundbMetadataStore implements UserMetadataStore {
     this.listUser.get(BucketMetadataCollection).set(nodeRef as unknown as EncryptedMetadata);
 
     return schema;
+  }
+
+  /**
+   * {@inheritDoc @spacehq/sdk#UserMetadataStore.setNotificationsLastSeenAt}
+   */
+  public async setNotificationsLastSeenAt(timestamp: number): Promise<void> {
+    const encryptedTimestamp = await this.encrypt(timestamp.toString());
+    const lookupKey = this.getNotificationsLastSeenAtLookupKey();
+    const nodeRef = this.lookupUser.get(lookupKey).put({ data: encryptedTimestamp });
+    this.listUser.get(NotificationsLastSeenAtCollection).set(nodeRef as unknown as EncryptedMetadata);
+  }
+
+  /**
+   * {@inheritDoc @spacehq/sdk#UserMetadataStore.getNotificationsLastSeenAt}
+   */
+  public async getNotificationsLastSeenAt(): Promise<number> {
+    this.logger?.info({ username: this.username }, 'Store.getNotificationsLastSeenAt');
+    const lookupKey = this.getNotificationsLastSeenAtLookupKey();
+    const res:number|undefined = await this.lookupUserData(lookupKey);
+    return res || 0;
   }
 
   /**
@@ -476,6 +497,10 @@ export class GundbMetadataStore implements UserMetadataStore {
         }
       }
     });
+  }
+
+  private getNotificationsLastSeenAtLookupKey(): string {
+    return `notifications/lastSeenAt/${this.username}`;
   }
 
   private getBucketsLookupKey(bucketSlug: string): string {

--- a/packages/storage/src/metadata/metadataStore.ts
+++ b/packages/storage/src/metadata/metadataStore.ts
@@ -101,6 +101,18 @@ export interface UserMetadataStore {
    *
    */
   listUsersRecentlySharedWith(): Promise<ShareUserMetadata[]>;
+
+  /**
+   * Set the notifications last seen at
+   *
+   */
+  setNotificationsLastSeenAt(timestamp: number): Promise<void>;
+
+    /**
+   * Get the notifications last seen at
+   *
+   */
+  getNotificationsLastSeenAt(): Promise<number>;
 }
 
 /**

--- a/packages/storage/src/userStorage.spec.ts
+++ b/packages/storage/src/userStorage.spec.ts
@@ -5,6 +5,7 @@ import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as chaiSubset from 'chai-subset';
 import dayjs from 'dayjs';
+import { noop } from 'lodash';
 import { anyString, anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import { v4 } from 'uuid';
 import { DirEntryNotFoundError, UnauthenticatedError } from './errors';
@@ -116,6 +117,12 @@ const initStubbedStorage = (): { storage: UserStorage; mockBuckets: Buckets } =>
           },
           async listUsersRecentlySharedWith(): Promise<ShareUserMetadata[]> {
             return [];
+          },
+          async getNotificationsLastSeenAt():Promise<number> {
+            return Date.now();
+          },
+          async setNotificationsLastSeenAt(timestamp:number):Promise<void> {
+            noop;
           },
         }),
     },

--- a/packages/storage/src/userStorage.ts
+++ b/packages/storage/src/userStorage.ts
@@ -851,13 +851,15 @@ export class UserStorage {
    *
    */
   public async getNotifications(seek?: string, limit?:number): Promise<GetNotificationsResponse> {
+    const metadataStore = await this.getMetadataStore();
+
     if (!this.mailbox) {
       await this.initMailbox();
     }
 
     const msgs: DecryptedUserMessage[] | undefined = await this.mailbox?.listInboxMessages(seek, limit);
     const notifs :Notification[] = [];
-    const lastSeenAt = new Date().getTime();
+    const lastSeenAt = await metadataStore.getNotificationsLastSeenAt();
     let lastId = '';
 
     if (!msgs) {
@@ -1011,6 +1013,19 @@ export class UserStorage {
     this.listener?.addListener(metadata.dbId);
 
     return { ...metadata, ...getOrCreateResponse };
+  }
+
+  /**
+   * setNotificationsLastSeenAt sets the field so that .
+   *
+   * @example
+   * ```typescript
+   * const result = await spaceStorage.setNotificationsLastSeenAt(Date.now());
+   * ```
+   */
+  public async setNotificationsLastSeenAt(timestamp:number):Promise<void> {
+    const metadataStore = await this.getMetadataStore();
+    await metadataStore.setNotificationsLastSeenAt(timestamp);
   }
 
   /**


### PR DESCRIPTION
## Description
This adds the `setNotificationsLastSeenAt` so the FE can set it.  And also `getNotifications` now returns this value properly.

https://app.clubhouse.io/terminalsystems/story/21022/setnotificationslastseenat

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Unit Test
- [x] Integration Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
