### PR TITLE
Hotfix: convert pub key for members.

### DIFF
--- a/integration_tests/sharing_interactions.spec.ts
+++ b/integration_tests/sharing_interactions.spec.ts
@@ -59,6 +59,9 @@ describe('Users sharing data', () => {
       }],
     });
 
+    const ld = await storage1.listDirectory({ bucket: 'personal', path: '' });
+    expect(ld.items[0].members[0].publicKey).to.equal(user2Pk);
+
     expect(shareResult.publicKeys).not.to.be.empty;
     expect(shareResult.publicKeys[0].type).to.equal(ShareKeyType.Existing);
     expect(shareResult.publicKeys[0].pk).not.to.be.empty;

--- a/packages/storage/src/userStorage.spec.ts
+++ b/packages/storage/src/userStorage.spec.ts
@@ -1,4 +1,5 @@
 import { Identity, GetAddressFromPublicKey } from '@spacehq/users';
+import { tryParsePublicKey } from '@spacehq/utils';
 import { PrivateKey } from '@textile/crypto';
 import { Buckets, PathAccessRole, PathItem, PushPathResult, Root } from '@textile/hub';
 import { expect, use } from 'chai';
@@ -221,7 +222,7 @@ describe('UserStorage', () => {
       expect(result.items[0].isLocallyAvailable).to.equal(false);
       expect(result.items[0].backupCount).to.equal(1);
       expect(result.items[0].members).to.deep.equal([{
-        publicKey: pubkey,
+        publicKey: Buffer.from(tryParsePublicKey(pubkey).pubKey).toString('hex'),
         role: PathAccessRole.PATH_ACCESS_ROLE_WRITER,
         address: GetAddressFromPublicKey(pubkey),
       }]);

--- a/packages/storage/src/userStorage.ts
+++ b/packages/storage/src/userStorage.ts
@@ -204,7 +204,7 @@ export class UserStorage {
 
         ms.forEach((v, k) => {
           members.push({
-            publicKey: k,
+            publicKey: Buffer.from(tryParsePublicKey(k).pubKey).toString('hex'),
             address: k === '*' ? '' : GetAddressFromPublicKey(k),
             role: v,
           });

--- a/packages/storage/src/userStorage.ts
+++ b/packages/storage/src/userStorage.ts
@@ -204,7 +204,7 @@ export class UserStorage {
 
         ms.forEach((v, k) => {
           members.push({
-            publicKey: Buffer.from(tryParsePublicKey(k).pubKey).toString('hex'),
+            publicKey: k === '*' ? '*' : Buffer.from(tryParsePublicKey(k).pubKey).toString('hex'),
             address: k === '*' ? '' : GetAddressFromPublicKey(k),
             role: v,
           });


### PR DESCRIPTION
## Description
Hotfix that converts pub keys on `DirectoryEntry` members so that it matches the format stored in identity sevice.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- [ ] Unit Test
- [x] Integration Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
