### PR TITLE
Hotfix: use admin for sharing, and pass uuid through notifs

### DIFF
--- a/integration_tests/sharing_interactions.spec.ts
+++ b/integration_tests/sharing_interactions.spec.ts
@@ -116,6 +116,7 @@ describe('Users sharing data', () => {
     expect(received.notifications[0].relatedObject?.itemPaths[0].bucket).to.equal('personal');
     expect(received.notifications[0].relatedObject?.itemPaths[0].path).to.equal('/top.txt');
     expect(received.notifications[0].relatedObject?.itemPaths[0].dbId).not.to.be.null;
+    expect(received.notifications[0].relatedObject?.itemPaths[0].uuid).to.equal(ld.items[0].uuid);
     expect(received.notifications[0].relatedObject?.itemPaths[0].bucketKey).not.to.be.null;
     expect(received.notifications[0].relatedObject?.keys[0]).not.to.be.null;
     expect(received.lastSeenAt).to.equal(ts);

--- a/packages/storage/src/sharing/sharing.ts
+++ b/packages/storage/src/sharing/sharing.ts
@@ -19,8 +19,15 @@ export const createFileInvitations = async (
 
   const bucketsAndEnhancedPaths = await Promise.all(paths.map(async (path) => {
     const b = await store.findBucket(path.bucket);
+
+    if (!b) {
+      throw new Error('Unable to find bucket metadata');
+    }
+
+    const f = await store.findFileMetadata(b.slug, b.dbId, path.path);
     return [b, {
       ...path,
+      uuid: f?.uuid,
       dbId: b?.dbId,
       bucketKey: b?.bucketKey,
     }];

--- a/packages/storage/src/sharing/sharing.ts
+++ b/packages/storage/src/sharing/sharing.ts
@@ -24,7 +24,7 @@ export const createFileInvitations = async (
       throw new Error('Unable to find bucket metadata');
     }
 
-    const f = await store.findFileMetadata(b.slug, b.dbId, path.path);
+    const f = await store.findFileMetadata(path.bucket, path.dbId || b.dbId, path.path);
     return [b, {
       ...path,
       uuid: f?.uuid,

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -264,6 +264,7 @@ export interface FullPath {
   bucket: string;
   bucketKey?: string;
   dbId?: string;
+  uuid?: string;
 }
 
 /**

--- a/packages/storage/src/userStorage.spec.ts
+++ b/packages/storage/src/userStorage.spec.ts
@@ -419,6 +419,7 @@ describe('UserStorage', () => {
             {
               bucket: 'personal',
               path: '/randomPath',
+              uuid: v4(),
             },
           ],
         }),
@@ -436,6 +437,7 @@ describe('UserStorage', () => {
             {
               bucket: 'personal',
               path: '/randomPath',
+              uuid: v4(),
             },
           ],
         }),

--- a/packages/storage/src/userStorage.ts
+++ b/packages/storage/src/userStorage.ts
@@ -837,7 +837,7 @@ export class UserStorage {
         dbId: fullPath.dbId || '',
         mimeType: '', // TODO: Update invitation to include mimeType from sender
         sharedBy: invitation.inviterPublicKey,
-        uuid: v4(),
+        uuid: fullPath.uuid,
         accepted: accept,
         invitationId,
       });
@@ -1124,8 +1124,7 @@ export class UserStorage {
       // eslint-disable-next-line no-restricted-syntax
       for (const path of paths) {
         const roles = new Map();
-        const role = (userKey.type === ShareKeyType.Temp)
-          ? PathAccessRole.PATH_ACCESS_ROLE_ADMIN : PathAccessRole.PATH_ACCESS_ROLE_WRITER;
+        const role = PathAccessRole.PATH_ACCESS_ROLE_ADMIN;
         roles.set(userKey.pk, role);
         await client.pushPathAccessRoles(path.key, path.fullPath.path, roles);
       }

--- a/packages/storage/src/userStorage.ts
+++ b/packages/storage/src/userStorage.ts
@@ -203,7 +203,7 @@ export class UserStorage {
       // swap access roles to new user
       await Promise.all(invitation.itemPaths.map(async (ivPaths) => {
         const roles = new Map<string, PathAccessRole>();
-        roles.set(currentUsersPublicKey, PathAccessRole.PATH_ACCESS_ROLE_WRITER);
+        roles.set(currentUsersPublicKey, PathAccessRole.PATH_ACCESS_ROLE_ADMIN);
         roles.set(tempUsersPublicKey, PathAccessRole.PATH_ACCESS_ROLE_UNSPECIFIED);
 
         tempUserClient.withThread(ivPaths.dbId);


### PR DESCRIPTION
## Description
Fixes UUID not matching between sharees and uses admin as the base role so that sharees can invite others.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Unit Test
- [x] Integration Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
