### PR TITLE
Fix: Enable Axe and Localstorage options for gundb

### DIFF
--- a/packages/storage/src/metadata/gundbMetadataStore.ts
+++ b/packages/storage/src/metadata/gundbMetadataStore.ts
@@ -101,9 +101,10 @@ export class GundbMetadataStore implements UserMetadataStore {
       }
     } else {
       this.gunInit = () => Gun({
-        localStorage: false,
+        localStorage: true,
         radisk: true,
         peers: 'https://gun.space.storage/gun',
+        axe: true,
       } as any);
     }
 

--- a/packages/storage/src/utils/pathUtils.spec.ts
+++ b/packages/storage/src/utils/pathUtils.spec.ts
@@ -7,6 +7,7 @@ describe('pathUtils', () => {
       { input: '/folder', output: '/folder' },
       { input: '/folder/', output: '/folder' },
       { input: 'folder', output: '/folder' },
+      { input: '', output: '/' },
       { input: 'folder/inside/', output: '/folder/inside' },
       { input: 'folder\\inside\\', output: '/folder/inside' },
     ];


### PR DESCRIPTION
## Description

Based on a recommendation from the gundb channels, this enables some more configuration to improve the ability of gundb to sync data with the relay peer.

It also enables local storage.


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration
-->

- [ ] Unit Test
- [ ] Integration Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
